### PR TITLE
feat: adding languages section and missing literals

### DIFF
--- a/src/adapters/views/form-steps/components/languages/index.tsx
+++ b/src/adapters/views/form-steps/components/languages/index.tsx
@@ -1,0 +1,104 @@
+import { LanguageSchema, type Language } from "../../../landing/schemas";
+import { useTranslation } from "react-i18next";
+import useCVStore from "@/store/cv";
+import { useCallback, useState, type FC } from "react";
+import Snackbar from "@/components/snackbar";
+import stepInputs from "./inputs";
+import Table from "../table";
+import Form from "@/components/form";
+
+interface LanguagesStepProps {
+  onNext: () => void;
+}
+
+const Languages: FC<LanguagesStepProps> = ({ onNext }) => {
+  const { t } = useTranslation();
+  const [showSnackbar, setShowSnackbar] = useState(false);
+  const onSave = useCVStore((state) => state.addLanguage);
+  const deleteLanguage = useCVStore((state) => state.removeLanguage);
+  const languages = useCVStore((state) => state.cvData.languages);
+
+  console.log(languages);
+
+  const onSubmit = useCallback(
+    (data: Language) => {
+      onSave(data);
+      setShowSnackbar(true);
+    },
+    [onSave, setShowSnackbar]
+  );
+
+  return (
+    <div className="mx-auto p-6">
+      <div className="mb-8">
+        <h2 className="text-2xl font-bold text-gray-900 mb-2">
+          {t("cv.builder.form.languages.title")}
+        </h2>
+        <p className="text-gray-600">
+          {t("cv.builder.form.languages.description")}
+        </p>
+      </div>
+
+      {/* Diseño responsivo mejorado */}
+      <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+        {/* Formulario - toma 1 columna en XL, full width en pantallas menores */}
+        <div className="xl:col-span-1">
+          <div className="bg-white rounded-lg shadow-sm border p-6">
+            <h3 className="text-lg font-semibold mb-4 text-gray-800">
+              {t("cv.builder.form.languages.form.title")}
+            </h3>
+            <Form<Language>
+              onSubmit={onSubmit}
+              schema={LanguageSchema}
+              fields={stepInputs}
+              btnSubmitText={t("cv.builder.form.languages.buttons.add")}
+            />
+          </div>
+        </div>
+
+        {/* Tabla - toma 2 columnas en XL, full width en pantallas menores */}
+        <div className="xl:col-span-2">
+          <div className="bg-white rounded-lg shadow-sm border p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-lg font-semibold text-gray-800">
+                {t("cv.builder.form.languages.table.title")}
+              </h3>
+              <span className="text-sm text-gray-500">
+                {languages?.length}
+                {languages?.length === 1
+                  ? t("cv.builder.form.languages.table.count.single")
+                  : t("cv.builder.form.languages.table.count.multiple")}
+              </span>
+            </div>
+            {languages?.length && languages?.length > 0 ? (
+              <Table data={languages ?? []} onDelete={deleteLanguage} />
+            ) : (
+              <div className="text-center py-8 text-gray-500">
+                <p>{t("cv.builder.form.languages.table.empty")}</p>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-8 flex justify-end">
+        <button
+          onClick={onNext}
+          className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
+          disabled={languages?.length === 0}
+        >
+          {t("cv.builder.form.languages.buttons.next")}
+        </button>
+      </div>
+
+      {showSnackbar && (
+        <Snackbar
+          message={t("cv.builder.form.languages.messages.successAdded")}
+          onClose={() => setShowSnackbar(false)}
+        />
+      )}
+    </div>
+  );
+};
+
+export default Languages;

--- a/src/adapters/views/form-steps/components/languages/inputs.ts
+++ b/src/adapters/views/form-steps/components/languages/inputs.ts
@@ -1,0 +1,51 @@
+import type { FormField } from "@/components/form/types";
+import { t } from "i18next";
+const stepInputs: FormField[][] = [
+  [
+    {
+      id: "name",
+      label: t("cv.builder.form.languages.fields.name.label"),
+      type: "input",
+      name: "name",
+      props: {
+        type: "text",
+        placeholder: t("cv.builder.form.languages.fields.name.placeholder"),
+        required: true,
+      },
+    },
+  ],
+  [
+    {
+      id: "reading",
+      label: t("cv.builder.form.languages.fields.reading.label"),
+      type: "input",
+      name: "reading",
+      props: {
+        placeholder: t("cv.builder.form.languages.fields.reading.placeholder"),
+        required: true,
+      },
+    },
+    {
+      id: "writing",
+      label: t("cv.builder.form.languages.fields.writing.label"),
+      type: "input",
+      name: "writing",
+      props: {
+        placeholder: t("cv.builder.form.languages.fields.writing.placeholder"),
+        required: true,
+      },
+    },
+    {
+      id: "speaking",
+      label: t("cv.builder.form.languages.fields.speaking.label"),
+      type: "input",
+      name: "speaking",
+      props: {
+        placeholder: t("cv.builder.form.languages.fields.speaking.placeholder"),
+        required: true,
+      },
+    },
+  ],
+];
+
+export default stepInputs;

--- a/src/adapters/views/form-steps/components/table.tsx
+++ b/src/adapters/views/form-steps/components/table.tsx
@@ -35,7 +35,7 @@ const Table: FC<TableProps> = ({ data, onDelete }) => {
   }
 
   return (
-    <div className="p-2">
+    <div className="p-2 overflow-x-auto">
       <table className="w-full border-collapse border border-gray-300">
         <thead>
           {table.getHeaderGroups().map((headerGroup) => (

--- a/src/adapters/views/form-steps/hooks/use-form-steps.ts
+++ b/src/adapters/views/form-steps/hooks/use-form-steps.ts
@@ -10,6 +10,7 @@ const STEPS: FormStep[] = [
   "education",
   "courses",
   "skills",
+  "languages",
 ];
 
 export const useFormSteps = () => {

--- a/src/adapters/views/form-steps/index.tsx
+++ b/src/adapters/views/form-steps/index.tsx
@@ -9,6 +9,7 @@ const Education = lazy(() => import("./components/education"));
 const Skills = lazy(() => import("./components/skills"));
 const Courses = lazy(() => import("./components/courses"));
 const Projects = lazy(() => import("./components/projects"));
+const Languages = lazy(() => import("./components/languages"));
 
 const FormSteps = () => {
   const { t } = useTranslation();
@@ -31,11 +32,13 @@ const FormSteps = () => {
       case "education":
         return <Education onNext={nextStep} />;
       case "skills":
-        return <Skills onNext={goToPreview} />;
+        return <Skills onNext={nextStep} />;
       case "courses":
         return <Courses onNext={nextStep} />;
       case "projects":
         return <Projects onNext={nextStep} />;
+      case "languages":
+        return <Languages onNext={goToPreview} />;
       default:
         return null;
     }

--- a/src/adapters/views/landing/schemas/index.ts
+++ b/src/adapters/views/landing/schemas/index.ts
@@ -2,6 +2,7 @@ export * from "./basics.schema";
 export * from "./course.schema";
 export * from "./cv.schema";
 export * from "./education.schema";
+export * from "./languages.schema";
 export * from "./location.schema";
 export * from "./profile.schema";
 export * from "./projects.schema";

--- a/src/adapters/views/landing/schemas/languages.schema.ts
+++ b/src/adapters/views/landing/schemas/languages.schema.ts
@@ -1,0 +1,19 @@
+import { t } from "i18next";
+import { z } from "zod";
+
+export const LanguageSchema = z.object({
+  name: z
+    .string()
+    .min(3, t("cv.builder.form.languages.validation.name.minLength")),
+  reading: z
+    .string()
+    .min(2, t("cv.builder.form.languages.validation.reading.minLength")),
+  writing: z
+    .string()
+    .min(2, t("cv.builder.form.languages.validation.writing.minLength")),
+  speaking: z
+    .string()
+    .min(2, t("cv.builder.form.languages.validation.speaking.minLength")),
+});
+
+export type Language = z.infer<typeof LanguageSchema>;

--- a/src/components/cv/index.tsx
+++ b/src/components/cv/index.tsx
@@ -5,6 +5,7 @@ import WorkSection from "./work-section.tsx";
 import EducationSection from "./education-section.tsx";
 import SkillsSection from "./skills-section.tsx";
 import ProjectsSection from "./projects-section.tsx";
+import LanguagesSection from "./languages.tsx";
 import "./styles/cv-print-styles.css";
 
 export const CVDisplay: React.FC = () => {
@@ -33,6 +34,11 @@ export const CVDisplay: React.FC = () => {
       {/* Projects Section */}
       {cvData.projects && cvData.projects.length > 0 && (
         <ProjectsSection projects={cvData.projects} />
+      )}
+
+      {/* Languages Section */}
+      {cvData.languages && cvData.languages.length > 0 && (
+        <LanguagesSection languages={cvData.languages} />
       )}
     </div>
   );

--- a/src/components/cv/languages.tsx
+++ b/src/components/cv/languages.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import type { Language } from "../../store/cv";
+
+interface LanguagesSectionProps {
+  languages: Language[];
+}
+
+export const LanguagesSection: React.FC<LanguagesSectionProps> = ({
+  languages,
+}) => {
+  const { t } = useTranslation();
+
+  if (!languages || languages.length === 0) return null;
+
+  return (
+    <section className="mb-8 print:mb-6 print:break-inside-avoid">
+      <h2 className="text-2xl print:text-xl font-bold text-gray-900 mb-4 print:mb-3 border-b border-gray-300 pb-2 print:pb-1">
+        {t("cv.builder.cv.sections.languages", "Idiomas")}
+      </h2>
+
+      <div className="space-y-3 print:space-y-2">
+        {languages.map((language, index) => (
+          <div
+            key={index}
+            className="bg-gray-50 print:bg-white border border-gray-200 print:border-gray-300 rounded-lg p-4 print:p-3 hover:bg-gray-100 print:hover:bg-white transition-colors print:break-inside-avoid"
+          >
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 print:gap-2">
+              {/* Nombre del idioma */}
+              <div className="flex items-center">
+                <span className="text-blue-600 print:text-gray-700 mr-2 text-lg print:text-base">
+                  🌐
+                </span>
+                <h3 className="text-lg print:text-base font-semibold text-gray-900">
+                  {language.name}
+                </h3>
+              </div>
+
+              {/* Niveles de competencia en línea */}
+              <div className="flex flex-wrap gap-2 print:gap-1 text-sm print:text-xs">
+                <div className="flex items-center gap-1">
+                  <span className="text-gray-600 print:text-gray-700 font-medium">
+                    {t("cv.builder.cv.labels.reading", "Lectura")}:
+                  </span>
+                  <span className="text-gray-800 print:text-gray-900 bg-blue-100 print:bg-gray-100 px-2 py-1 print:px-1 print:py-0.5 rounded-md print:rounded-sm font-medium">
+                    {language.reading}
+                  </span>
+                </div>
+
+                <span className="text-gray-300 print:text-gray-400">|</span>
+
+                <div className="flex items-center gap-1">
+                  <span className="text-gray-600 print:text-gray-700 font-medium">
+                    {t("cv.builder.cv.labels.writing", "Escritura")}:
+                  </span>
+                  <span className="text-gray-800 print:text-gray-900 bg-green-100 print:bg-gray-100 px-2 py-1 print:px-1 print:py-0.5 rounded-md print:rounded-sm font-medium">
+                    {language.writing}
+                  </span>
+                </div>
+
+                <span className="text-gray-300 print:text-gray-400">|</span>
+
+                <div className="flex items-center gap-1">
+                  <span className="text-gray-600 print:text-gray-700 font-medium">
+                    {t("cv.builder.cv.labels.speaking", "Habla")}:
+                  </span>
+                  <span className="text-gray-800 print:text-gray-900 bg-purple-100 print:bg-gray-100 px-2 py-1 print:px-1 print:py-0.5 rounded-md print:rounded-sm font-medium">
+                    {language.speaking}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default LanguagesSection;

--- a/src/components/cv/work-section.tsx
+++ b/src/components/cv/work-section.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import type { WorkExperience } from "../../store/cv";
 
 interface WorkSectionProps {
@@ -6,6 +7,8 @@ interface WorkSectionProps {
 }
 
 export const WorkSection: React.FC<WorkSectionProps> = ({ workExperience }) => {
+  const { t } = useTranslation();
+
   if (!workExperience || workExperience.length === 0) return null;
 
   const formatDate = (dateString: string) => {
@@ -19,7 +22,7 @@ export const WorkSection: React.FC<WorkSectionProps> = ({ workExperience }) => {
   return (
     <section className="mb-8 print:mb-6 print:break-inside-avoid">
       <h2 className="text-2xl print:text-xl font-bold text-gray-900 mb-4 print:mb-3 border-b border-gray-300 pb-2 print:pb-1">
-        Experiencia Laboral
+        {t("cv.builder.cv.sections.work", "Experiencia Laboral")}
       </h2>
 
       <div className="space-y-6 print:space-y-4">
@@ -54,7 +57,9 @@ export const WorkSection: React.FC<WorkSectionProps> = ({ workExperience }) => {
               <div className="text-sm print:text-xs text-gray-600 font-medium">
                 {formatDate(work.startDate)}
                 {" - "}
-                {work.endDate ? formatDate(work.endDate) : "Presente"}
+                {work.endDate
+                  ? formatDate(work.endDate)
+                  : t("cv.builder.cv.labels.present", "Presente")}
               </div>
             </div>
 

--- a/src/libs/i18n/locales/en/translations.json
+++ b/src/libs/i18n/locales/en/translations.json
@@ -1,1 +1,60 @@
-{}
+{
+  "cv.builder": {
+    "form": {
+      "languages": {
+        "title": "Languages",
+        "description": "Add the languages you speak with their proficiency levels",
+        "form": {
+          "title": "Add Language"
+        },
+        "table": {
+          "title": "Added Languages",
+          "empty": "No languages added yet",
+          "count": {
+            "single": "entry",
+            "multiple": "entries"
+          }
+        },
+        "fields": {
+          "name": {
+            "label": "Language *",
+            "placeholder": "E.g: Spanish, English, French"
+          },
+          "reading": {
+            "label": "Reading *",
+            "placeholder": "E.g: Native, Advanced, Intermediate, Basic"
+          },
+          "writing": {
+            "label": "Writing *",
+            "placeholder": "E.g: Native, Advanced, Intermediate, Basic"
+          },
+          "speaking": {
+            "label": "Speaking *",
+            "placeholder": "E.g: Native, Advanced, Intermediate, Basic"
+          }
+        },
+        "buttons": {
+          "add": "Add",
+          "next": "Next"
+        },
+        "messages": {
+          "successAdded": "Language added successfully"
+        },
+        "validation": {
+          "name": {
+            "minLength": "Language name must have at least 2 characters"
+          },
+          "reading": {
+            "minLength": "Reading level must have at least 5 characters"
+          },
+          "writing": {
+            "minLength": "Writing level must have at least 5 characters"
+          },
+          "speaking": {
+            "minLength": "Speaking level must have at least 5 characters"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/libs/i18n/locales/es/translations.json
+++ b/src/libs/i18n/locales/es/translations.json
@@ -45,7 +45,8 @@
         "projects": "Proyectos",
         "education": "Educación",
         "courses": "Cursos",
-        "skills": "Habilidades"
+        "skills": "Habilidades",
+        "languages": "Idiomas"
       },
       "basics": {
         "title": "Información Personal",
@@ -364,6 +365,127 @@
             "invalidDate": "La fecha de fin no es válida",
             "mustBeAfterStart": "La fecha de fin debe ser posterior a la fecha de inicio"
           }
+        }
+      },
+      "languages": {
+        "title": "Idiomas",
+        "description": "Añade los idiomas que dominas con su nivel de competencia",
+        "form": {
+          "title": "Agregar Idioma"
+        },
+        "table": {
+          "title": "Idiomas Agregados",
+          "empty": "No hay idiomas agregados aún",
+          "count": {
+            "single": "entrada",
+            "multiple": "entradas"
+          }
+        },
+        "fields": {
+          "name": {
+            "label": "Idioma *",
+            "placeholder": "Ej: Español, Inglés, Francés"
+          },
+          "reading": {
+            "label": "Lectura *",
+            "placeholder": "Ej: Nativo, Avanzado, Intermedio, Básico"
+          },
+          "writing": {
+            "label": "Escritura *",
+            "placeholder": "Ej: Nativo, Avanzado, Intermedio, Básico"
+          },
+          "speaking": {
+            "label": "Habla *",
+            "placeholder": "Ej: Nativo, Avanzado, Intermedio, Básico"
+          }
+        },
+        "buttons": {
+          "add": "Añadir",
+          "next": "Siguiente"
+        },
+        "messages": {
+          "successAdded": "Idioma añadido con éxito"
+        },
+        "validation": {
+          "name": {
+            "minLength": "El nombre del idioma debe tener al menos 2 caracteres"
+          },
+          "reading": {
+            "minLength": "El nivel de lectura debe tener al menos 5 caracteres"
+          },
+          "writing": {
+            "minLength": "El nivel de escritura debe tener al menos 5 caracteres"
+          },
+          "speaking": {
+            "minLength": "El nivel de habla debe tener al menos 5 caracteres"
+          }
+        }
+      }
+    },
+    "cv": {
+      "sections": {
+        "basics": "Información Personal",
+        "work": "Experiencia Laboral",
+        "education": "Educación",
+        "skills": "Habilidades Técnicas",
+        "projects": "Proyectos",
+        "languages": "Idiomas"
+      },
+      "labels": {
+        "present": "Presente",
+        "demo": "Demo",
+        "code": "Código",
+        "reading": "Lectura",
+        "writing": "Escritura",
+        "speaking": "Habla",
+        "entries": {
+          "single": "entrada",
+          "multiple": "entradas"
+        }
+      },
+      "work": {
+        "table": {
+          "title": "Experiencias Agregadas",
+          "empty": "No hay experiencias agregadas aún"
+        },
+        "form": {
+          "title": "Agregar Experiencia"
+        }
+      },
+      "education": {
+        "table": {
+          "title": "Educación Agregada",
+          "empty": "No hay educación agregada aún"
+        },
+        "form": {
+          "title": "Agregar Educación"
+        }
+      },
+      "skills": {
+        "table": {
+          "title": "Habilidades Agregadas",
+          "empty": "No hay habilidades agregadas aún"
+        },
+        "form": {
+          "title": "Agregar Habilidad"
+        }
+      },
+      "projects": {
+        "table": {
+          "title": "Proyectos Agregados",
+          "empty": "No hay proyectos agregados aún"
+        },
+        "form": {
+          "title": "Agregar Proyecto"
+        }
+      },
+      "languages": {
+        "table": {
+          "title": "Idiomas Agregados",
+          "empty": "No hay idiomas agregados aún"
+        },
+        "form": {
+          "title": "Agregar Idioma"
         }
       }
     }

--- a/src/store/cv.ts
+++ b/src/store/cv.ts
@@ -6,7 +6,8 @@ export type FormStep =
   | "education"
   | "skills"
   | "courses"
-  | "projects";
+  | "projects"
+  | "languages";
 
 // Tipos principales
 export interface Location {
@@ -43,6 +44,13 @@ export interface WorkExperience {
   summary: string;
 }
 
+export interface Language {
+  name: string;
+  reading: string;
+  writing: string;
+  speaking: string;
+}
+
 export interface Education {
   institution: string;
   url?: string;
@@ -68,6 +76,7 @@ export interface CVData {
   skills: string[];
   projects: Project[];
   courses: Education[];
+  languages: Language[];
 }
 
 // Tipos para el store
@@ -96,6 +105,8 @@ export interface CVStore {
   removeProject: (index: number) => void;
   addSkill: (skills: string) => void;
   removeSkill: (index: number) => void;
+  addLanguage: (language: Language) => void;
+  removeLanguage: (index: number) => void;
 
   // Acciones para navegación del formulario
   setTotalSteps: (total: number) => void;
@@ -128,6 +139,7 @@ const initialCVData: Partial<CVData> = {
   work: [],
   education: [],
   projects: [],
+  languages: [],
 };
 
 // Store con Zustand
@@ -238,6 +250,22 @@ const useCVStore = create<CVStore>((set, get) => ({
       cvData: {
         ...state.cvData,
         skills: state.cvData.skills?.filter((_, i) => i !== index) || [],
+      },
+    })),
+
+  addLanguage: (language: Language) =>
+    set((state) => ({
+      cvData: {
+        ...state.cvData,
+        languages: [...(state.cvData.languages || []), language],
+      },
+    })),
+
+  removeLanguage: (index: number) =>
+    set((state) => ({
+      cvData: {
+        ...state.cvData,
+        languages: state.cvData.languages?.filter((_, i) => i !== index) || [],
       },
     })),
 


### PR DESCRIPTION
This pull request adds a complete "Languages" step to the CV builder, allowing users to input, validate, and display their language skills with proficiency levels. It introduces new form components, schema validation, and updates the CV preview to include a dedicated languages section. Additionally, it enhances internationalization support for these new features in both English and Spanish.

The most important changes are:

**Languages Feature Integration:**

* Added a new form step for languages, including a dedicated component (`languages/index.tsx`), input definitions (`languages/inputs.ts`), and schema validation (`languages.schema.ts`). This includes UI for adding, listing, and deleting languages, with success feedback. [[1]](diffhunk://#diff-7a5b6ddc2841ee4b38386a400d5393d94aae7cffac5cfb3e0ab9125fed419898R1-R104) [[2]](diffhunk://#diff-c3cfefa8c1eb6b8fdca43a031f1e69d379191c60460d9b3490c79addaa138173R1-R51) [[3]](diffhunk://#diff-12a7ca245ed107221f0d19163170e2d07afc4ea3a2a6ad51c5da75107964a9ccR1-R19)
* Updated the form step flow and types to include the new "languages" step (`use-form-steps.ts`, `cv.ts`), and registered the schema export. [[1]](diffhunk://#diff-335343c515fc0a85e354847c6946b7ec43ebcfbb45bebef680dce7aa35e71de5R13) [[2]](diffhunk://#diff-5389e08d3ef188cbeadf5af460d1aa8864da0f07b2390076b085cf72a2be4856L9-R10) [[3]](diffhunk://#diff-5389e08d3ef188cbeadf5af460d1aa8864da0f07b2390076b085cf72a2be4856R79) [[4]](diffhunk://#diff-3e2493d877320c5b24dbfa6353d900bd031887b2ccd0559f99985505e1d100b5R5)

**CV Preview and Display Enhancements:**

* Added a new `LanguagesSection` component for displaying languages in the CV preview, and integrated it into the main CV display. [[1]](diffhunk://#diff-6f3b63a80b23c395f7fb1e7d6b7e49cbb95a45ae6fdd8855bbb46f3dadc0b699R1-R80) [[2]](diffhunk://#diff-e1c8e51863b92ad8af86ba9a37dd7b6a1da02224f346a037dee60a62d5dded7dR8) [[3]](diffhunk://#diff-e1c8e51863b92ad8af86ba9a37dd7b6a1da02224f346a037dee60a62d5dded7dR38-R42)

**Internationalization (i18n):**

* Added translations for all language-related UI and validation messages in both English and Spanish, including section titles and field labels. [[1]](diffhunk://#diff-36e08f4cf88869e84be34172427c3bd4f9b8fa19dee0ee9c0cda654cf28ea48cL1-R60) [[2]](diffhunk://#diff-ef0a1228cacdfb47e8c6a1af7a71f0ef4aa73f57b10d4a9e9bad5a4ee9109f3bL48-R49) [[3]](diffhunk://#diff-ef0a1228cacdfb47e8c6a1af7a71f0ef4aa73f57b10d4a9e9bad5a4ee9109f3bR369-R489)

**General Improvements:**

* Made the work section and other UI elements translatable by using i18n for section titles and dynamic labels. [[1]](diffhunk://#diff-911f7dab0b19ffa08bfc7c05c2a9170f5b4fc11759dd0fbc0cf83e64711b13b9R2-R11) [[2]](diffhunk://#diff-911f7dab0b19ffa08bfc7c05c2a9170f5b4fc11759dd0fbc0cf83e64711b13b9L22-R25) [[3]](diffhunk://#diff-911f7dab0b19ffa08bfc7c05c2a9170f5b4fc11759dd0fbc0cf83e64711b13b9L57-R62)
* Improved table responsiveness in the form steps UI.

These changes collectively provide a robust, user-friendly way to manage and display language skills in the CV builder, with full internationalization support.